### PR TITLE
Send badge count in OneSignal notification

### DIFF
--- a/realm/lib/realm-chat.hoon
+++ b/realm/lib/realm-chat.hoon
@@ -661,6 +661,8 @@
           ['data' (mtd data.notif)]
           ['include_player_ids' a+(turn player-ids |=([id=@t] s+id))]
           ['headings' (contents title.notif)]
+          ['ios_badgeType' s+'SetTo']
+          ['ios_badgeCount' (numb unread.data.notif)]
       ==
       =/  extended-list
         ?~  subtitle.notif  base-list
@@ -680,7 +682,6 @@
       %-  pairs
       :~
         ['path-row' (path-row:encode:chat-db path-row.mtd)]
-        ['unread_count' (numb unread.mtd)]
         ['avatar' ?~(avatar.mtd ~ s+u.avatar.mtd)]
         ['msg' a+(turn message.mtd |=(m=msg-part:db (messages-row:encode:chat-db [msg-id.m msg-part-id.m] m)))]
       ==


### PR DESCRIPTION
In OneSignal, you can set the badge count by using the ios_badgeType and ios_badgeCount fields in the API payload:

```json
{
  "app_id": "your-app-id",
  "include_player_ids": ["player-id-1", "player-id-2"],
  "contents": {"en": "Your message"},
  "ios_badgeType": "SetTo",
  "ios_badgeCount": 1
}
```

* ios_badgeType: Sets the operation to perform. Can be "SetTo", "Increase", or "None".
* ios_badgeCount: The number to set or increase the badge by.

Reference: https://documentation.onesignal.com/docs/badges#send-push-with-badges---ios

We can also remove the `unread` field as that is unused.