### PR TITLE
slowly fill backlog and tell expected count

### DIFF
--- a/realm/app/realm-chat.hoon
+++ b/realm/app/realm-chat.hoon
@@ -139,6 +139,7 @@
     |=  [=wire =sign:agent:gall]
     ^-  (quip card _this)
     ?+    wire  !!
+      [%thread @ ~]  `this
       [%dbpoke ~]
       :: [%dbpoke *]
         ?+    -.sign  `this

--- a/realm/lib/chat-db.hoon
+++ b/realm/lib/chat-db.hoon
@@ -208,8 +208,8 @@
 ::
 :: MUST EXPLICITLY INCLUDE SELF, this function will not add self into peers list
 ++  create-path
-::chat-db &db-action [%create-path /a/path/to/a/chat ~ %chat *@da *@da ~ %host *@dr *@dr ~[[~zod %host] [~bus %member]]]
-  |=  [[row=path-row:sur peers=ship-roles:sur] state=state-2 =bowl:gall]
+::chat-db &db-action [%create-path /a/path/to/a/chat ~ %chat *@da *@da ~ %host *@dr *@dr ~[[~zod %host] [~bus %member]] 100]
+  |=  [[row=path-row:sur peers=ship-roles:sur expected-msg-count=@ud] state=state-2 =bowl:gall]
   ^-  (quip card state-2)
 
   ?>  ?!((~(has by paths-table.state) path.row))  :: ensure the path doesn't already exist!!!
@@ -224,10 +224,13 @@
   =.  peers-table.state  (~(put by peers-table.state) path.row thepeers)
   =/  thechange  chat-db-change+!>((limo [[%add-row %paths row] (turn thepeers |=(p=peer-row:sur [%add-row %peers p]))]))
   =/  vent-path=path  /chat-vent/(scot %da created-at.row)
+  =/  vnt
+  ?:  =(0 expected-msg-count)  chat-vent+!>([%path row])
+  chat-vent+!>([%path-and-count row expected-msg-count])
   =/  gives  :~
     [%give %fact [/db (weld /db/path path.row) ~] thechange]
     :: give vent response
-    [%give %fact ~[vent-path] chat-vent+!>([%path row])]
+    [%give %fact ~[vent-path] vnt]
     [%give %kick ~[vent-path] ~]
   ==
   [gives state]
@@ -289,6 +292,8 @@
   |=  [=path state=state-2 =bowl:gall]
   ^-  (quip card state-2)
   ?>  =(our.bowl src.bowl)  :: leave pokes are only valid from ourselves. if others want to kick us, that is a different matter
+  ~&  %leaving-path
+  ~&  path
   =.  messages-table.state  messages-table:s:(remove-messages-for-path state path now.bowl)
   =.  paths-table.state  (~(del by paths-table.state) path)
   =.  peers-table.state  (~(del by peers-table.state) path)
@@ -343,6 +348,7 @@
 :: :chat-db &db-action [%insert-backlog list-of-msg-parts]
   |=  [=message:sur state=state-2 =bowl:gall]
   ^-  (quip card state-2)
+  ~&  (lent message)
   ?:  =(0 (lent message))  `state  :: if the list is empty, don't do anything
   =/  index=@ud   0
   =/  changes=db-change:sur  *db-change:sur
@@ -361,7 +367,7 @@
       :: created-at.msg (because the message was from *before* we
       :: joined the chat)
       =/  us-peer   (snag 0 (skim peers |=(p=peer-row:sur =(patp.p our.bowl))))
-      ?>  (gth created-at.us-peer created-at.msg)
+      ?:  (lth created-at.us-peer created-at.msg)  $(index +(index))  :: skip msgs from after we joined
       :: has to be from a ship that has invite-potential in the path
       ?>  (is-valid-inviter pathrow peers src.bowl our.bowl)
       :: the path has to be %.y on peers-get-backlog
@@ -872,6 +878,11 @@
         %ack     s/%ack
         %msg     a+(turn message.chat-vent |=(m=msg-part:sur (messages-row [msg-id.m msg-part-id.m] m)))
         %path    (path-row path-row.chat-vent)
+        %path-and-count
+      %-  pairs
+      :~  path+(path-row path-row.chat-vent)
+          msg-count+(numb msg-count.chat-vent)
+      ==
       ==
     ::
     ++  time-bunt-null

--- a/realm/lib/chat-db.hoon
+++ b/realm/lib/chat-db.hoon
@@ -224,13 +224,10 @@
   =.  peers-table.state  (~(put by peers-table.state) path.row thepeers)
   =/  thechange  chat-db-change+!>((limo [[%add-row %paths row] (turn thepeers |=(p=peer-row:sur [%add-row %peers p]))]))
   =/  vent-path=path  /chat-vent/(scot %da created-at.row)
-  =/  vnt
-  ?:  =(0 expected-msg-count)  chat-vent+!>([%path row])
-  chat-vent+!>([%path-and-count row expected-msg-count])
   =/  gives  :~
     [%give %fact [/db (weld /db/path path.row) ~] thechange]
     :: give vent response
-    [%give %fact ~[vent-path] vnt]
+    [%give %fact ~[vent-path] chat-vent+!>([%path-and-count row expected-msg-count])]
     [%give %kick ~[vent-path] ~]
   ==
   [gives state]

--- a/realm/lib/spaces-chat.hoon
+++ b/realm/lib/spaces-chat.hoon
@@ -78,8 +78,6 @@
     %+  turn  all-peers
     |=  [s=ship role=@tas]
     (create-path-db-poke:rc-lib s pathrow all-peers)
-  ~&  (snag 0 cards)
-  ~&  (snag 1 cards)
   [cards new-chat]
 
 :: matching members are status %joined or %host AND have

--- a/realm/sur/chat-db.hoon
+++ b/realm/sur/chat-db.hoon
@@ -105,7 +105,7 @@
 +$  ship-roles  (list [s=@p role=@tas])
 +$  action
   $%  
-      [%create-path =path-row peers=ship-roles]
+      [%create-path =path-row peers=ship-roles expected-msg-count=@ud]
       [%edit-path =path metadata=(map cord cord) peers-get-backlog=? invites=@tas max-expires-at-duration=@dr]
       [%edit-path-pins =path =pins]
       [%leave-path =path]
@@ -148,6 +148,7 @@
 +$  chat-vent
   $%  [%msg =message]
       [%path =path-row]
+      [%path-and-count =path-row msg-count=@ud]
       [%ack ~]
   ==
 ::

--- a/realm/ted/make-fake-chats.hoon
+++ b/realm/ted/make-fake-chats.hoon
@@ -1,0 +1,56 @@
+:: -realm!make-fake-chats 10
+/-  spider, chat-db, realm-chat
+/+  *strandio
+
+|^
+=,  strand=strand:spider
+^-  thread:spider
+|=  arg=vase
+=/  m  (strand ,vase)
+^-  form:m
+=/  axn=(unit @ud)  !<((unit @ud) arg)
+?~  axn  (strand-fail %no-arg ~)
+;<  our=@p   bind:m  get-our
+;<  now=@da  bind:m  get-time
+=/  =wire  /chat-vent/(scot %da now)
+;<  ~   bind:m  (watch wire [our %chat-db] wire)
+;<  ~   bind:m  (poke [our %realm-chat] chat-action+!>([%vented-create-chat now ~ %chat ~[~bud ~dev] %host *@dr]))
+;<  cage=(unit cage)  bind:m  (take-fact-or-kick wire)
+?~  cage  (pure:m !>([%ack ~]))
+=/  ven=chat-vent:chat-db    !<(chat-vent:chat-db q.u.cage)
+=/  pth=path
+?+  -.ven  !!
+  %path  path.path-row.ven
+  %path-and-count  path.path-row.ven
+==
+;<  ~   bind:m  (poke [our %realm-chat] chat-action+!>([%edit-chat pth ~ %.y %host *@dr]))
+=/  i=@ud  1
+|-
+  ?:  =(u.axn i)
+    (pure:m q.u.cage)
+  =/  frag=minimal-fragment:chat-db
+  ?:  =(0 (mod i 2))
+    [[%bold (scot %ud i)] ~ ~]
+  [[%plain (scot %ud i)] ~ ~]
+  ;<  ~   bind:m  (poke [our %realm-chat] chat-action+!>(`action:realm-chat`[%vented-send-message (add now i) pth [frag ~] *@dr]))
+  $(i +(i))
+::
+++  take-fact-or-kick
+  |=  =wire
+  =/  m  (strand ,(unit cage))
+  ^-  form:m
+  |=  tin=strand-input:strand
+  ?+  in.tin  `[%skip ~]
+      ~  `[%wait ~]
+    ::
+      [~ %agent * %fact *]
+    ?.  =(watch+wire wire.u.in.tin)
+      `[%skip ~]
+    `[%done (some cage.sign.u.in.tin)]
+    ::
+      [~ %agent * %kick *]
+    ?.  =(watch+wire wire.u.in.tin)
+      `[%skip ~]
+    `[%done ~]
+  ==
+--

--- a/realm/ted/send-backlog.hoon
+++ b/realm/ted/send-backlog.hoon
@@ -1,0 +1,26 @@
+:: -realm!send-backlog path ship
+/-  spider, chat-db, realm-chat
+/+  *strandio, realm-chat
+
+|^
+=,  strand=strand:spider
+^-  thread:spider
+|=  arg=vase
+=/  m  (strand ,vase)
+^-  form:m
+~&  "send-backlog starting"
+=/  axn=(unit [=path =ship])  !<((unit [=path =ship]) arg)
+?~  axn  (strand-fail %no-arg ~)
+~&  axn
+;<  our=@p   bind:m  get-our
+;<  now=@da  bind:m  get-time
+=/  msgs  (scry-messages-for-path:realm-chat path.u.axn our now)
+|-
+  ?:  =((lent msgs) 0)
+    (pure:m !>(~))
+  ~&  (lent msgs)
+  =/  next  (turn (scag 1.000 msgs) |=([k=uniq-id:chat-db v=msg-part:chat-db] v))
+  ;<  ~  bind:m  (poke [ship.u.axn %chat-db] chat-db-action+!>([%insert-backlog next]))
+  ;<  ~  bind:m  (sleep ~s1)
+  $(msgs (oust [0 1.000] msgs))
+--


### PR DESCRIPTION
this requires updating the vent result parsers on the client side since we have a new vent-type that includes the expected message count