### PR TITLE
dashes

### DIFF
--- a/realm/app/bedrock.hoon
+++ b/realm/app/bedrock.hoon
@@ -175,6 +175,10 @@
         [%db ~]  :: the "everything" path
           ?>  =(our.bowl src.bowl)
           ~  :: we are not "priming" this subscription with anything, since the client can just scry if they need. the sub is for receiving new updates
+      ::
+        [%db %common ~]  :: the "common-types only" path
+          ?>  =(our.bowl src.bowl)
+          ~  :: we are not "priming" this subscription with anything, since the client can just scry if they need. the sub is for receiving new updates
       :: /path/the/actual/path/
         [%path *]  :: the "path" path, subscribe by path explicitly
           ?>  =(our.bowl src.bowl)

--- a/realm/app/passport.hoon
+++ b/realm/app/passport.hoon
@@ -145,7 +145,9 @@
           ``passport-template-root+!>(p)
         =/  m=passport-data-link-metadata:common
         [
-          'FILL_IN'
+          ?.  =((lent chain-owner-entities.pki-state.crypto.op) 1)
+            'FILL_IN'
+          (snag 0 chain-owner-entities.pki-state.crypto.op)
           'FILL_IN'
           1
           'FILL_IN'

--- a/realm/app/passport.hoon
+++ b/realm/app/passport.hoon
@@ -129,11 +129,11 @@
             now.bowl
             '0x00000000000000000000000000000000'
             [
-              ['passport_root' ~]
-              (malt ['passport_root' ['FILL_IN' ~]]~)
+              [(scot %p our.bowl) ~]
+              (malt [(scot %p our.bowl) ['FILL_IN' ~]]~)
               (malt ['FILL_IN' 0]~)
-              (malt ['passport_root' 1.728]~)
-              (malt ['FILL_IN' 'passport_root']~)
+              (malt [(scot %p our.bowl) 1.728]~)
+              (malt ['FILL_IN' (scot %p our.bowl)]~)
             ]
             [
               (limo ~['ENTITY_ADD' 'ENTITY_REMOVE' 'KEY_ADD' 'KEY_REMOVE' 'NAME_RECORD_SET'])

--- a/realm/app/passport.hoon
+++ b/realm/app/passport.hoon
@@ -117,6 +117,47 @@
     ::
       [%x %passport-state ~]
         ``passport-state+!>(state)
+    ::
+      [%x %template %next-block %metadata-or-root ~]
+        =/  op=passport:common  (our-passport:scries bowl)
+        ?:  =(0 (lent chain.op))
+          =/  p=passport-crypto:common
+          [
+            'PASSPORT_ROOT'
+            0
+            0
+            now.bowl
+            '0x00000000000000000000000000000000'
+            [
+              ['passport_root' ~]
+              (malt ['passport_root' ['FILL_IN' ~]]~)
+              (malt ['FILL_IN' 0]~)
+              (malt ['passport_root' 1.728]~)
+              (malt ['FILL_IN' 'passport_root']~)
+            ]
+            [
+              (limo ~['ENTITY_ADD' 'ENTITY_REMOVE' 'KEY_ADD' 'KEY_REMOVE' 'NAME_RECORD_SET'])
+              ''
+            ]
+            [(limo ['NAME_RECORD' ~]) '']
+            [144 1.000 'FILL_IN' o+(malt ['NAME_RECORD' o+~]~)]
+          ]
+          ``passport-template-root+!>(p)
+        =/  m=passport-data-link-metadata:common
+        [
+          'FILL_IN'
+          'FILL_IN'
+          1
+          'FILL_IN'
+          0
+          0
+          '0x00000000000000000000000000000000'
+          ?~(chain.op 0 (dec (lent chain.op)))
+          ?:((lth (lent chain.op) 2) '0x00000000000000000000000000000000' hash:(rear chain.op))
+          ?~(chain.op 0 (dec (lent chain.op)))
+          now.bowl
+        ]
+        ``passport-template+!>(m)
     ==
   ::
   ++  on-agent

--- a/realm/app/passport.hoon
+++ b/realm/app/passport.hoon
@@ -56,6 +56,8 @@
 
       %get     :: for getting someone else's passport via a threadpoke
         (get:passport +.act state bowl)
+      %get-contact  :: for getting someone else's contact via a threadpoke
+        (get-contact:passport +.act state bowl)
       %add-link
         (add-link:passport +.act state bowl)
       %change-contact

--- a/realm/lib/passport.hoon
+++ b/realm/lib/passport.hoon
@@ -1275,7 +1275,7 @@
       |=  m=passport-data-link-metadata:common
       ^-  json
       %-  pairs
-      :~  ['link-id' s+link-id.m]
+      :~  ['from-entity' s+from-entity.m]
           ['signing-address' s+signing-address.m]
           ['value' (numb value.m)]
           ['link-id' s+link-id.m]

--- a/realm/lib/passport.hoon
+++ b/realm/lib/passport.hoon
@@ -413,6 +413,7 @@
 ::passport &passport-action [%get [our now]]
   |=  [=req-id state=state-0 =bowl:gall]
   ^-  (quip card state-0)
+  ?<  =(src.bowl our.bowl)  :: crash if we're poking ourself, that's dumb
   =/  log1  (maybe-log hide-logs.state "%get: {<req-id>} from {<src.bowl>}")
 
   =/  vent-path=path  /vent/(scot %p src.req-id)/(scot %da now.req-id)
@@ -427,6 +428,30 @@
   =/  cards=(list card)
     :-  [%give %fact ~[vent-path] passport-vent+!>([%passport pass])]
     :-  kickcard
+    :-  [%pass /contacts %agent [src.bowl dap.bowl] %poke %passport-action !>([%receive-contacts [[now.bowl contact.pass] ~]])]
+    ~
+  [cards state]
+::
+++  get-contact
+:: for getting our contact
+::passport &passport-action [%get-contact [our now]]
+  |=  [=req-id state=state-0 =bowl:gall]
+  ^-  (quip card state-0)
+  =/  log1  (maybe-log hide-logs.state "%get: {<req-id>} from {<src.bowl>}")
+
+  =/  vent-path=path  /vent/(scot %p src.req-id)/(scot %da now.req-id)
+  =/  kickcard=card  [%give %kick ~[vent-path] ~]
+
+  =/  pass=passport:common   (our-passport:scries bowl)
+  =/  src-fren=?  (is-friend:scries src.bowl bowl)
+  :: only actually give out the passport if we are discoverable
+  :: OR we are friends with the requester
+  ?>  |(discoverable.pass src-fren)
+
+  =/  cards=(list card)
+    :-  [%give %fact ~[vent-path] passport-vent+!>([%contact contact.pass])]
+    :-  kickcard
+    :-  [%pass /contacts %agent [src.bowl dap.bowl] %poke %passport-action !>([%receive-contacts [[now.bowl contact.pass] ~]])]
     ~
   [cards state]
 ::
@@ -970,6 +995,7 @@
       %-  of
       :~  [%add-link add-link]
           [%get de-get]
+          [%get-contact de-get]
           [%add-friend de-add-friend]
           [%cancel-friend-request de-cancel-friend-request]
           [%handle-friend-request de-handle-friend-request]
@@ -1078,6 +1104,7 @@
       ?-  -.vent
         %ack        s/%ack
         %passport   (en-passport passport.vent)
+        %contact    (en-contact contact.vent)
         %friend     (en-friend friend.vent)
         %link       ~
       ==

--- a/realm/lib/passport.hoon
+++ b/realm/lib/passport.hoon
@@ -299,6 +299,7 @@
   =/  log1  (maybe-log hide-logs.state "%add-friend: {<req-id>} {<ship>}")
 
   =/  new-fren=friend:common      [ship %pending-outgoing %.n mtd]
+  =/  pass=passport:common   (our-passport:scries bowl)
 
   :: check that we don't already have a friendship with this ship
   =/  frs=(list friend:common)    (get-friends:scries bowl)
@@ -307,7 +308,7 @@
     ?~  (find [ship ~] ships)
       :~  (create-req our.bowl friend-type:common [%friend new-fren] req-id)
           [%pass /selfpoke %agent [ship dap.bowl] %poke %passport-action !>([%get-friend mtd])]
-          (req ship dap.bowl)
+          [%pass /contacts %agent [ship dap.bowl] %poke %passport-action !>([%receive-contacts [[now.bowl contact.pass] ~]])]
       ==
     ~
   [cards state]
@@ -319,9 +320,10 @@
   =/  log1  (maybe-log hide-logs.state "%get-friend: {<mtd>} from {<src.bowl>}")
 
   =/  new-fren=friend:common  [src.bowl %pending-incoming %.n mtd]
+  =/  pass=passport:common   (our-passport:scries bowl)
 
   =/  cards=(list card)
-    :~  (req src.bowl dap.bowl)
+    :~  [%pass /contacts %agent [src.bowl dap.bowl] %poke %passport-action !>([%receive-contacts [[now.bowl contact.pass] ~]])]
         (create our.bowl friend-type:common [%friend new-fren])
     ==
   [cards state]
@@ -386,7 +388,6 @@
         kickcard
         (edit our.bowl friend-type:common id.new-fren [%friend friend.new-fren])
         [%pass /selfpoke %agent [ship dap.bowl] %poke %passport-action !>([%respond-to-friend-request accept])]
-        (req ship dap.bowl)
     ==
   [cards state]
 ::

--- a/realm/lib/passport.hoon
+++ b/realm/lib/passport.hoon
@@ -782,7 +782,7 @@
         %-  some
         ?+  `@tas`p.typ  !!
           %image  [%image (so (~(got by p.jon) 'img'))]
-          %nft    [%nft (so (~(got by p.jon) 'nft'))]
+          %nft    [%nft (so (~(got by p.jon) 'img'))]
         ==
     ==
   ::
@@ -1217,7 +1217,7 @@
       :-
         ?-  -.u.a
           %image  ['img' s+img.u.a]
-          %nft  ['nft' s+nft.u.a]
+          %nft    ['img' s+nft.u.a]
         ==
       :~  ['type' [%s -.u.a]]
       ==

--- a/realm/lib/passport.hoon
+++ b/realm/lib/passport.hoon
@@ -69,9 +69,6 @@
 ++  verify-message
   |=  [msg=@t sig=@t addr=@t]  ^-  ?
   =/  pubkey=@ux  (recover-pub-key msg sig addr)
-  ~&  >>>  pubkey
-  ~&  >>>  "addr {<addr>} address-from-pub {<(address-from-pub:key:eth pubkey)>}"
-
   :: if the passed in address equals the address for the the recovered public key of the sig, then it is verified
   =((hex-to-num:eth addr) (address-from-pub:key:eth pubkey))
 ::
@@ -1074,18 +1071,27 @@
       ^-  json
       %-  pairs
       :~  ['link-id' s+link-id.cryp]
-          ['epoch-block' (numb epoch-block.cryp)]
-          ['data-block' (numb data-block.cryp)]
+          ['epoch-block-number' (numb epoch-block.cryp)]
+          ['data-block-number' (numb data-block.cryp)]
           ['timestamp' (time timestamp.cryp)]
           ['previous-epoch-hash' s+previous-epoch-hash.cryp]
           ['pki-state' (en-pki-state pki-state.cryp)]
-          ['transaction-types' s+%not-implemented]
-          ['data-structs' s+%not-implemented]
+          :-  'transaction-types'
+          %-  pairs
+          :~  ['link-names' a+(turn link-names.transaction-types.cryp |=(t=@t s+t))]
+              ['link-structs' s+link-structs.transaction-types.cryp]
+          ==
+          :-  'data-structs'
+          %-  pairs
+          :~  ['struct-names' a+(turn struct-names.data-structs.cryp |=(t=@t s+t))]
+              ['struct-types' s+struct-types.data-structs.cryp]
+          ==
           :-  'sig-chain-settings'
           %-  pairs
           :~  ['new-entity-balance' (numb new-entity-balance.sig-chain-settings.cryp)]
               ['epoch-length' (numb epoch-length.sig-chain-settings.cryp)]
               ['signing-key' s+signing-key.sig-chain-settings.cryp]
+              ['data-state' data-state.sig-chain-settings.cryp]
           ==
       ==
     ::
@@ -1239,6 +1245,23 @@
           ['status' s+status.n]
           ['pinned' b+pinned.n]
           ['mtd' (metadata-to-json mtd.n)]
+      ==
+    ::
+    ++  en-pdl-metadata
+      |=  m=passport-data-link-metadata:common
+      ^-  json
+      %-  pairs
+      :~  ['link-id' s+link-id.m]
+          ['signing-address' s+signing-address.m]
+          ['value' (numb value.m)]
+          ['link-id' s+link-id.m]
+          ['epoch-block-number' (numb epoch-block-number.m)]
+          ['previous-epoch-nonce' (numb previous-epoch-nonce.m)]
+          ['previous-epoch-hash' s+previous-epoch-hash.m]
+          ['nonce' (numb nonce.m)]
+          ['previous-link-hash' s+previous-link-hash.m]
+          ['data-block-number' (numb data-block-number.m)]
+          ['timestamp' (time timestamp.m)]
       ==
     ::
     ++  row-id-to-json

--- a/realm/lib/passport.hoon
+++ b/realm/lib/passport.hoon
@@ -1,6 +1,3 @@
-::  db [realm]:
-::  TODO:
-::  - constraints via paths-table settings
 /-  *passport, common, db
 /+  scries=bedrock-scries, eth=ethereum
 |%
@@ -483,9 +480,7 @@
 
   =/  p=passport:common   (our-passport:scries bowl)
   =/  old-contact=contact:common  contact.p
-  :: TODO verify the link is valid, then save it to bedrock
-  :: also probably need to make updates to `crypto.p` and the pki state
-
+  :: verify the link is valid, then save it to bedrock
   :: validate the hash of data is what the payload claims it is
   ?>  =((shax data.ln) (ether-hash-to-ux hash.ln))
 
@@ -506,7 +501,6 @@
       p
     ?:  =('KEY_ADD' link-type.ln)
       ?>  (validate-signing-key p ln)   :: only allow keys that are already in the crypto state to add other keys
-      :: TODO check previous_link_hash
       =/  parsed-link=passport-data-link:common   (passport-data-link:dejs (need (de:json:html data.ln)))
       ?>  (prev-link-hash-matches parsed-link chain.p)
       =/  entity=@t     from-entity.mtd.parsed-link
@@ -533,8 +527,7 @@
       p
       ==
     ?:  =('NAME_RECORD_SET' link-type.ln)
-      ?>  (validate-signing-key p ln)   :: only allow keys that are already in the crypto state to update the name_record
-      :: TODO check previous_link_hash
+      ?>  (validate-signing-key p ln)   :: only allow keys that are already in the crypto state to update the name-record
       =/  parsed-link=passport-data-link:common   (passport-data-link:dejs (need (de:json:html data.ln)))
       ?>  (prev-link-hash-matches parsed-link chain.p)
       ?+  -.data.parsed-link  !!
@@ -791,10 +784,10 @@
     ^-  passport-data-link:common
     ?>  ?=([%o *] jon)
     =/  gt  ~(got by p.jon)
-    =/  pmtd=passport-data-link-metadata:common  (de-passport-data-link-metadata (gt 'link_metadata'))
+    =/  pmtd=passport-data-link-metadata:common  (de-passport-data-link-metadata (gt 'link-metadata'))
     [
       pmtd
-      (de-passport-link (gt 'link_data') link-id.pmtd)
+      (de-passport-link (gt 'link-data') link-id.pmtd)
     ]
   ::
   ++  de-passport-link
@@ -803,7 +796,7 @@
     ?>  ?=([%o *] jon)
     =/  gt  ~(got by p.jon)
     ?:  =('KEY_ADD' typ)
-      [%key-add (so (gt 'address')) (so (gt 'address_type')) (so (gt 'entity_name'))]
+      [%key-add (so (gt 'address')) (so (gt 'address-type')) (so (gt 'entity-name'))]
     ?:  =('NAME_RECORD_SET' typ)
       [%name-record-set (so (gt 'name')) (so (gt 'record'))]
     !!
@@ -836,30 +829,30 @@
   ::
   ++  de-passport-data-link-metadata
     %-  ot
-    :~  ['from_entity' so]
-        ['signing_address' so]
+    :~  ['from-entity' so]
+        ['signing-address' so]
         ['value' ni]
-        ['link_id' so]
-        ['epoch_block_number' ni]
-        ['previous_epoch_nonce' ni]
-        ['previous_epoch_hash' so]
+        ['link-id' so]
+        ['epoch-block-number' ni]
+        ['previous-epoch-nonce' ni]
+        ['previous-epoch-hash' so]
         ['nonce' ni]
-        ['previous_link_hash' so]
-        ['data_block_number' ni]
+        ['previous-link-hash' so]
+        ['data-block-number' ni]
         ['timestamp' di]
     ==
   ::
   ++  passport-root
     %-  ot
-    :~  ['link_id' so]
-        ['epoch_block_number' ni]
-        ['data_block_number' ni]
+    :~  ['link-id' so]
+        ['epoch-block-number' ni]
+        ['data-block-number' ni]
         ['timestamp' di]
-        ['previous_epoch_hash' so]
-        ['pki_state' de-pki-state]
-        ['transaction_types' (ot ~[['link_names' (ar so)] ['link_structs' so]])]
-        ['data_structs' (ot ~[['struct_names' (ar so)] ['struct_types' so]])]
-        ['sig_chain_settings' (ot ~[['new_entity_balance' ni] ['epoch_length' ni] ['signing_key' so] ['data_state' nuthing]])]
+        ['previous-epoch-hash' so]
+        ['pki-state' de-pki-state]
+        ['transaction-types' (ot ~[['link-names' (ar so)] ['link-structs' so]])]
+        ['data-structs' (ot ~[['struct-names' (ar so)] ['struct-types' so]])]
+        ['sig-chain-settings' (ot ~[['new-entity-balance' ni] ['epoch-length' ni] ['signing-key' so] ['data-state' nuthing]])]
     ==
   ::
   ++  nuthing
@@ -888,11 +881,11 @@
     ==
   ++  de-pki-state
     %-  ot
-    :~  ['chain_owner_entities' (ar so)]
-        ['entity_to_addresses' (om (ar so))]
-        ['address_to_nonce' (om ni)]
-        ['entity_to_value' (om ni)]
-        ['address_to_entity' (om so)]
+    :~  ['chain-owner-entities' (ar so)]
+        ['entity-to-addresses' (om (ar so))]
+        ['address-to-nonce' (om ni)]
+        ['entity-to-value' (om ni)]
+        ['address-to-entity' (om so)]
     ==
   ::
   ++  de-contact
@@ -1020,10 +1013,10 @@
     ::
     ++  de-add-link
       %-  ot
-      :~  ['link_type' so]
+      :~  [%link-type so]
           [%data so]
           [%hash so]
-          ['signature_of_hash' so]
+          [%signature-of-hash so]
       ==
     ++  de-get
       :: allow people to pass {"request-id": "/~zod/~2000.1.1"} or {"ship": "~zod"}
@@ -1111,10 +1104,10 @@
       |=  ln=passport-link-container:common
       ^-  json
       %-  pairs
-      :~  ['link_type' s+link-type.ln]
+      :~  [%link-type s+link-type.ln]
           ['data' s+data.ln]
           ['hash' s+hash.ln]
-          ['signature_of_hash' s+hash-signature.ln]
+          [%signature-of-hash s+hash-signature.ln]
       ==
     ::
     ++  en-link

--- a/realm/mar/passport/template-root.hoon
+++ b/realm/mar/passport/template-root.hoon
@@ -1,16 +1,17 @@
 /-  common
 /+  lib=passport
 ::
-|_  c=(list contact:common)
+|_  c=passport-crypto:common
 ++  grad  %noun
 ++  grow
   |%
   ++  noun  c
-  ++  json  a+(turn c en-contact:enjs:lib)
+  ++  json  (en-p-crypto:enjs:lib c)
   --
 ::
 ++  grab
   |%
-  ++  noun  (list contact:common)
+  ++  noun  passport-crypto:common
   --
 --
+

--- a/realm/mar/passport/template.hoon
+++ b/realm/mar/passport/template.hoon
@@ -1,0 +1,17 @@
+/-  common
+/+  lib=passport
+::
+|_  c=passport-data-link-metadata:common
+++  grad  %noun
+++  grow
+  |%
+  ++  noun  c
+  ++  json  (en-pdl-metadata:enjs:lib c)
+  --
+::
+++  grab
+  |%
+  ++  noun  passport-data-link-metadata:common
+  --
+--
+

--- a/realm/sur/common.hoon
+++ b/realm/sur/common.hoon
@@ -247,7 +247,7 @@
       [%entity-add address=@t address-type=@t name=@t]
       [%entity-remove name=@t]
       [%key-add address=@t address-type=@t name=@t]
-      [%key-remove name=@t]
+      [%key-remove address=@t]
       [%post-add type=@t data=json]
       [%post-edit link-hash=@t type=@t data=json]
       [%post-remove link-hash=@t]

--- a/realm/sur/passport.hoon
+++ b/realm/sur/passport.hoon
@@ -15,6 +15,7 @@
                                                                 :: @da is updated-at on the bedrock row
       [%request-contacts ~] :: other ship send this to us to ask us to give them our whole peers list
       [%get =req-id]  :: when a client wants to threadpoke and get a full passport for a given ship
+      [%get-contact =req-id]  :: when a client wants to threadpoke and get a contact for a given ship
       [%add-friend =req-id =ship mtd=(map @t @t)]     :: client to ship
       [%get-friend mtd=(map @t @t)]                   :: ship to ship
       [%cancel-friend-request =req-id =ship]      :: client to ship
@@ -36,6 +37,7 @@
 +$  vent
   $%  [%link =passport-link:common]
       [%passport =passport:common]
+      [%contact =contact:common]
       [%friend =friend:common]
       [%ack ~]
   ==

--- a/realm/ted/passport-vent.hoon
+++ b/realm/ted/passport-vent.hoon
@@ -13,6 +13,7 @@
 =/  axn=(unit action:passport)  !<((unit action:passport) arg)
 ?~  axn  (strand-fail %no-arg ~)
 ?.  ?|  ?=(%get -.u.axn)
+        ?=(%get-contact -.u.axn)
         ?=(%add-friend -.u.axn)
         ?=(%cancel-friend-request -.u.axn)
         ?=(%handle-friend-request -.u.axn)
@@ -29,6 +30,13 @@
   %get
     ;<  ~  bind:m  (watch wire [src.req-id.u.axn %passport] wire)
     ;<  ~  bind:m  (poke [src.req-id.u.axn %passport] passport-action+!>([%get [our now]]))
+    ;<  cage=(unit cage)  bind:m  (take-fact-or-kick wire)
+    ?^  cage
+      (pure:m q.u.cage)
+    (pure:m !>([%ack ~]))
+  %get-contact
+    ;<  ~  bind:m  (watch wire [src.req-id.u.axn %passport] wire)
+    ;<  ~  bind:m  (poke [src.req-id.u.axn %passport] passport-action+!>([%get-contact [our now]]))
     ;<  cage=(unit cage)  bind:m  (take-fact-or-kick wire)
     ?^  cage
       (pure:m q.u.cage)


### PR DESCRIPTION
use dashes in passport object keys instead of underscores
POSTMAN has been updated to match this branch, and the signature-chain-js reference code has been updated to match as well

also adds the template scry to help clients know what the server expects for the next block
uses `"FILL_IN"` to indicate what values should be replaced

{{URL}}/~/scry/passport/template/next-block/metadata-or-root.json

also introduces `/db/common` subscription path to bedrock