### PR TITLE
add SIGNED_KEY_ADD data-link type to passport

### DIFF
--- a/realm/sur/common.hoon
+++ b/realm/sur/common.hoon
@@ -255,7 +255,7 @@
       [%token-burn from-entity=@t amount=@rd]
       [%token-mint to-entity=@t amount=@rd]
       [%token-transfer to-entity=@t amount=@rd]
-      [%signed-key-add address=@t address-type=@t address-signature=@t name=@t]
+      [%signed-key-add address=@t address-type=@t key-signature=@t name=@t nonce=@ud timestamp=@ud]
   ==
 +$  passport-data-link
   $:  mtd=passport-data-link-metadata

--- a/realm/sur/common.hoon
+++ b/realm/sur/common.hoon
@@ -255,6 +255,7 @@
       [%token-burn from-entity=@t amount=@rd]
       [%token-mint to-entity=@t amount=@rd]
       [%token-transfer to-entity=@t amount=@rd]
+      [%signed-key-add address=@t address-type=@t address-signature=@t name=@t]
   ==
 +$  passport-data-link
   $:  mtd=passport-data-link-metadata


### PR DESCRIPTION
this also requires a change to the PASSPORT_ROOT record (though the agent won't fail without it, but should still do it) to add SIGNED_KEY_ADD to the `transaction-types.link-names` array in the inital payload

the examples in postman have been updated to match this

```json
"link-data":{
  "address":"0xB983B84AD18A92448727647Ff98EC95Fd2201C9A",
  "address-type":"metamask",
  "entity-name":"passport_root",
  "key-signature":"0x7a625fb9a2f1f3110c2c2a657dede270f82be0591f63162c9000ea256f5f27f538721e77772b7e021c946284fbdb4e3ab773adf703aea9c603af1e65bb4b66ce1b",
  "nonce":123,
  "timestamp":1697053187881
}
```