### PR TITLE
Nuke profile

### DIFF
--- a/realm/app/profile.hoon
+++ b/realm/app/profile.hoon
@@ -14,7 +14,13 @@
     ==
 +$  state-0
   $:  %0
+      ::  map of filename => mime data
       toc=glob
+      :: registry is a list of ships that want to be notified when the passport
+      ::  UI is updated
+      registry=(set =ship)
+      ::  passport profile open graph image. used in <meta> tag of served passport page
+      opengraph-image=(unit @t)
   ==
 --
 %-  agent:dbug

--- a/realm/app/profile.hoon
+++ b/realm/app/profile.hoon
@@ -44,11 +44,19 @@
   |=  old-state=vase
   ~&  >>  "on-load"
   ^-  (quip card _this)
-  =/  old  !<(versioned-state old-state)
-  :_  this(state old)
-  ::  bind this agent to requests to /passport route
-  :~  [%pass /passport-route %arvo %e %connect `/'passport' %profile]
-  ==
+  :: =/  old  !<(versioned-state old-state)
+  :: :_  this(state old)
+  :: ::  bind this agent to requests to /passport route
+  :: :~  [%pass /passport-route %arvo %e %connect `/'passport' %profile]
+  :: ==
+  %-  (slog leaf+"nuking old %profile state" ~) ::  temporarily doing this for making development easier
+  =^  cards  this  on-init
+  :_  this
+  =-  (welp - cards)
+  %+  turn  ~(tap in ~(key by wex.bowl))
+  |=  [=wire =ship =term]
+  ^-  card
+  [%pass wire %agent [ship term] %leave ~]
 ::
 ++  on-poke
   |=  [=mark =vase]


### PR DESCRIPTION
this will get profile agent to a 'zero state'. once this is deployed and propagates, will remove the auto-nuke and handle state upgrades going forward.