### PR TITLE
use passport as signature source for nft-owner address

### DIFF
--- a/realm/app/chat-db.hoon
+++ b/realm/app/chat-db.hoon
@@ -384,13 +384,19 @@
           [[%pass /timer %arvo %b %rest next-expire-time:core] [%pass /timer %arvo %b %wait next-expire-time:core] ~]
           this
         ]
-      [%nft-verify @ @ *]
-        =/  act=[t=@da =path patp=ship]
+      [%nft-verify @ @ @ @ @ @ @ *]
+        =/  act=[t=@da =path patp=ship =nft-sig:sur]
         :*  `@da`(slav %da i.t.t.wire)
-            `path`t.t.t.wire
+            `path`t.t.t.t.t.t.t.t.wire
             `@p`(slav %p i.t.wire)
+            %-  some  [
+              i.t.t.t.wire
+              i.t.t.t.t.wire
+              i.t.t.t.t.t.wire
+              `@ud`(slav %ud i.t.t.t.t.t.t.wire)
+              `@ud`(slav %ud i.t.t.t.t.t.t.t.wire)
+            ]
         ==
-        =/  original-peers-list   (~(got by peers-table.state) path.act)
         =/  pathrow               (~(got by paths-table.state) path.act)
         ?>  ?=(%iris -.sign-arvo)
         =/  i  +.sign-arvo
@@ -408,26 +414,10 @@
             ~&  >  "found matching contract {<nft.pathrow>} {<(snag 0 contracts)>}"
             %.y
           $(contracts +.contracts)
-        :: WARNING MUST KEEP LOGIC IN SYNC WITH add-peer
-        =/  row=peer-row:sur   [
-          path.act
-          patp.act
-          %member
-          now.bowl
-          now.bowl
-          now.bowl
-        ]
-        =/  peers  (snoc original-peers-list row)
-        =.  peers-table.state  (~(put by peers-table.state) path.act peers)
-        =/  thechange  chat-db-change+!>(~[[%add-row [%peers row]]])
-        =/  vent-path=path  /chat-vent/(scot %da t.act)
-        =/  gives  :~
-          [%give %fact [/db (weld /db/path path.act) ~] thechange]
-          :: give vent response
-          [%give %fact ~[vent-path] chat-vent+!>([%path (~(got by paths-table.state) path.act)])]
-          [%give %kick ~[vent-path] ~]
-        ==
-        [gives this]
+
+        =^  cards  state
+        (finish-add-peer:db-lib act state bowl)
+        [cards this]
     ==
   ::
   ++  on-fail

--- a/realm/app/chat-db.hoon
+++ b/realm/app/chat-db.hoon
@@ -404,13 +404,14 @@
         ?>  ?=(%finished -.+.i)
         =/  payload  full-file.client-response.i
         ?~  payload  `this
+        =/  cleaned-contract=@t  (crip (cass (trip contract:(need nft.pathrow))))
         =/  contracts=(list @t)
           (parse-alchemy-json (need (de:json:html q.data.u.payload)))
         ?>  |-
           ?:  =((lent contracts) 0)
             ~&  >>>  "failed to find matching contract {<nft.pathrow>}"
             %.n
-          ?:  =(contract:(need nft.pathrow) (snag 0 contracts))
+          ?:  =(cleaned-contract (snag 0 contracts))
             ~&  >  "found matching contract {<nft.pathrow>} {<(snag 0 contracts)>}"
             %.y
           $(contracts +.contracts)
@@ -443,5 +444,5 @@
   ^-  @t
   ?>  ?=([%o *] jn)
   =/  address=json  (~(got by p.jn) 'address')
-  (so:dejs:format address)
+  (crip (cass (trip (so:dejs:format address))))
 --

--- a/realm/app/realm-chat.hoon
+++ b/realm/app/realm-chat.hoon
@@ -360,13 +360,14 @@
       ?>  ?=(%finished -.+.i)
       =/  payload  full-file.client-response.i
       ?~  payload  `this
+      =/  cleaned-contract=@t  (crip (cass (trip contract:(need nft.pathrow))))
       =/  contracts=(list @t)
         (parse-alchemy-json (need (de:json:html q.data.u.payload)))
       ?>  |-
         ?:  =((lent contracts) 0)
           ~&  >>>  "failed to find matching contract {<nft.pathrow>}"
           %.n
-        ?:  =(contract:(need nft.pathrow) (snag 0 contracts))
+        ?:  =(cleaned-contract (snag 0 contracts))
           ~&  >  "found matching contract {<nft.pathrow>} {<(snag 0 contracts)>}"
           %.y
         $(contracts +.contracts)
@@ -528,5 +529,5 @@
   ^-  @t
   ?>  ?=([%o *] jn)
   =/  address=json  (~(got by p.jn) 'address')
-  (so:dejs:format address)
+  (crip (cass (trip (so:dejs:format address))))
 --

--- a/realm/app/realm-chat.hoon
+++ b/realm/app/realm-chat.hoon
@@ -334,11 +334,47 @@
   ++  on-leave
     |=  path
       `this
-  :: we don't care about arvo
+  ::
   ++  on-arvo
     |=  [=wire =sign-arvo]
     ^-  (quip card _this)
-    `this
+    ?+  wire  !!
+        [%nft-verify @ @ @ @ @ @ @ *]
+      =/  act=[t=@da =path patp=ship host=(unit ship) =nft-sig]
+      :*  `@da`(slav %da i.t.t.wire)
+          `path`t.t.t.t.t.t.t.t.wire
+          `@p`(slav %p i.t.wire)
+          ~
+          %-  some  [
+            i.t.t.t.wire
+            i.t.t.t.t.wire
+            i.t.t.t.t.t.wire
+            `@ud`(slav %ud i.t.t.t.t.t.t.wire)
+            `@ud`(slav %ud i.t.t.t.t.t.t.t.wire)
+          ]
+      ==
+      =/  pathrow  (scry-path-row:lib path.act bowl)
+      ?>  ?=(%iris -.sign-arvo)
+      =/  i  +.sign-arvo
+      ?>  ?=(%http-response -.i)
+      ?>  ?=(%finished -.+.i)
+      =/  payload  full-file.client-response.i
+      ?~  payload  `this
+      =/  contracts=(list @t)
+        (parse-alchemy-json (need (de:json:html q.data.u.payload)))
+      ?>  |-
+        ?:  =((lent contracts) 0)
+          ~&  >>>  "failed to find matching contract {<nft.pathrow>}"
+          %.n
+        ?:  =(contract:(need nft.pathrow) (snag 0 contracts))
+          ~&  >  "found matching contract {<nft.pathrow>} {<(snag 0 contracts)>}"
+          %.y
+        $(contracts +.contracts)
+
+      =^  cards  state
+      (finish-add-ship-to-chat:lib act state bowl)
+      [cards this]
+    ==
   ::
   ++  on-fail
     |=  [=term =tang]
@@ -481,4 +517,16 @@
       t
     $(t (weld (trip c) t))
 ::
+++  parse-alchemy-json
+  |=  jon=json
+  ^-  (list @t)
+  ?>  ?=([%o *] jon)
+  =/  contracts=json  (~(got by p.jon) 'contracts')
+  ?>  ?=([%a *] contracts)
+  %+  turn  p.contracts
+  |=  jn=json
+  ^-  @t
+  ?>  ?=([%o *] jn)
+  =/  address=json  (~(got by p.jn) 'address')
+  (so:dejs:format address)
 --

--- a/realm/lib/crypto-helper.hoon
+++ b/realm/lib/crypto-helper.hoon
@@ -70,4 +70,50 @@
       $(ready +.ready)
     `@ux`(slav %ux (crip ['0' 'x' ready]))
 ::
+++  signed-key-add-msg
+  |=  [new-entity=@t new-key=@t nonce=@ud timestamp=@ud]
+  ^-  @t
+  %-  crip
+  ^-  tape
+  :~  new-entity
+      ' owns '
+      new-key
+      ', '
+      (ud-to-t nonce)
+      ', '
+      (ud-to-t timestamp)
+  ==
+::
+++  ud-to-t
+  |=  a=@u
+  ^-  @t
+  ?:  =(0 a)  '0'
+  %-  crip
+  %-  flop
+  |-  ^-  tape
+  ?:(=(0 a) ~ [(add '0' (mod a 10)) $(a (div a 10))])
+::
+++  check-alchemy
+  |=  [=path patp=@p t=@da chain=@t nft-sig=[sig=@t addr=@t name=@t nonce=@ud t=@ud]]
+  ^-  (list card:agent:gall)
+  =/  url=@t
+  %-  crip
+  :~  'https://realm-server-test.plymouth.network/alchemy/nfts/'
+    chain
+    '/'
+    addr.nft-sig
+  ==
+  =/  =request:http  [%'GET' url ~ ~]
+  ~&  >  "sending {<url>}"
+  :_  ~
+  :*  %pass
+      %+  weld
+        /nft-verify/(scot %p patp)/(scot %da t)/[sig.nft-sig]/[addr.nft-sig]/[name.nft-sig]/(scot %ud nonce.nft-sig)/(scot %ud t.nft-sig)
+      path
+      %arvo
+      %i
+      %request
+      request
+      *outbound-config:iris
+  ==
 --

--- a/realm/lib/passport.hoon
+++ b/realm/lib/passport.hoon
@@ -26,15 +26,6 @@
   ?~  (find [key]~ keys)  %.n  ::invalid signing key
   %.y
 ::
-++  ud-to-t
-  |=  a=@u
-  ^-  @t
-  ?:  =(0 a)  '0'
-  %-  crip
-  %-  flop
-  |-  ^-  ^tape
-  ?:(=(0 a) ~ [(add '0' (mod a 10)) $(a (div a 10))])
-::
 ++  parse-signing-key
   |=  ln=passport-link-container:common
   ^-  @t
@@ -516,7 +507,6 @@
       =/  key=@t        signing-address.mtd.parsed-link
       ?+  -.data.parsed-link  !!
         %key-add
-      =/  new-key-type=@t   address-type.data.parsed-link
       =/  new-key=@t        address.data.parsed-link
       =/  new-entity=@t     name.data.parsed-link
       ::  add new key to the pki-state for the new-entity
@@ -530,7 +520,7 @@
       =.  address-to-nonce.pki-state.crypto.p    (~(put by address-to-nonce.pki-state.crypto.p) new-key 0)
       :: update known addresses
       =/  sig=crypto-signature:common  [data.ln hash.ln hash-signature.ln t-pk]
-      =.  addresses.p  (snoc addresses.p [new-key-type new-key '' sig])
+      =.  addresses.p  (snoc addresses.p [address-type.data.parsed-link new-key '' sig])
       p
       ==
     ?:  =('SIGNED_KEY_ADD' link-type.ln)
@@ -539,20 +529,15 @@
       ?+  -.data.parsed-link  !!
         %signed-key-add
       =/  new-sig=@t        key-signature.data.parsed-link
-      =/  new-key-type=@t   address-type.data.parsed-link
       =/  new-key=@t        address.data.parsed-link
       =/  new-entity=@t     name.data.parsed-link
       =/  msg=@t
-      %-  crip
-      ^-  tape
-      :~  new-entity
-          ' owns '
+        %:  signed-key-add-msg:crypto-helper
+          new-entity
           new-key
-          ', '
-          (ud-to-t nonce.data.parsed-link)
-          ', '
-          (ud-to-t timestamp.data.parsed-link)
-      ==  
+          nonce.data.parsed-link
+          timestamp.data.parsed-link
+        ==
       ?>  (verify-message:crypto-helper msg new-sig new-key)
       ::  add new key to the pki-state for the new-entity
       =/  keys=(list @t)  (~(got by entity-to-addresses.pki-state.crypto.p) new-entity)
@@ -569,7 +554,7 @@
       %-  crip
       %-  num-to-hex:crypto-helper
       (recover-pub-key:crypto-helper msg new-sig new-key)
-      =.  addresses.p  (snoc addresses.p [new-key-type new-key new-pk sig])
+      =.  addresses.p  (snoc addresses.p [address-type.data.parsed-link new-key new-pk sig])
       p
       ==
     ?:  =('KEY_REMOVE' link-type.ln)

--- a/realm/sur/chat-db.hoon
+++ b/realm/sur/chat-db.hoon
@@ -105,6 +105,7 @@
 ::  agent details
 ::
 +$  ship-roles  (list [s=@p role=@tas])
++$  nft-sig    (unit [sig=@t addr=@t name=@t nonce=@ud t=@ud])
 +$  action
   $%  
       [%create-path =path-row peers=ship-roles expected-msg-count=@ud t=(unit @da)]
@@ -116,7 +117,7 @@
       [%edit =edit-message-action]
       [%delete =msg-id]
       [%delete-backlog =path before=time]
-      [%add-peer t=@da =path patp=ship signature=(unit [sig=@t addr=@t])]
+      [%add-peer t=@da =path patp=ship =nft-sig]
       [%kick-peer =path patp=ship]
       [%dump-to-bedrock ~]
       [%dump-to-bedrock-messages our-paths=(list path-row)]

--- a/realm/sur/realm-chat.hoon
+++ b/realm/sur/realm-chat.hoon
@@ -48,7 +48,7 @@
       =message:db
   ==
 ::
-+$  nft-sig    (unit [sig=@t addr=@t])
++$  nft-sig    nft-sig:db
 ::
 +$  action
   $%


### PR DESCRIPTION
tested both signature and nft/alchemy verification

the new add-ship-to-chat poke format:
```json
{
    "add-ship-to-chat": {
        "path": "/realm-chat/0v6.7k85b.b1sr0.dqajp.pnk9s.83fg6",
        "host": "~bus",
        "ship": "~zod",
        "nft-owner": "0xB983B84AD18A92448727647Ff98EC95Fd2201C9A"
    }
}
```