### PR TITLE
Fix reset passport

### DIFF
--- a/realm/lib/db.hoon
+++ b/realm/lib/db.hoon
@@ -1267,7 +1267,7 @@
     ==
 ::
 ++  create
-::bedrock &db-action [%create [~zod now] /example %foo 0 [%general ~[1 'a']] ~[['num' 'ud'] ['str' 't']]]
+::bedrock &db-action [%create [~zod now] /example [%foo 0v3.vumvj.9vf1a.f3lje.d8i4e.vrmeu] 0 [%general ~[1 'a']] ~[['num' 'ud'] ['str' 't']]]
 ::bedrock &db-action [%create /example %vote 0 [%vote [%.y our %foo [~zod now] /example]] ~]
 ::bedrock &db-action [%create /example %foo 1 [%general ~[1 'd' (jam /hello/goodbye)]] ~[['num' 'ud'] ['str' 't'] ['mypath' 'path']]]
 ::~zod/bedrock &db-action [%create /example %vote 0 [%vote %.y our %foo [~zod now] /example] ~]
@@ -1278,14 +1278,14 @@
   =/  kickcard=card  [%give %kick ~[vent-path] ~]
   :: form row from input
   =/  created-time=@da  
-    ?:(=(now.req-id *@da) now.bowl ?:((gth now.bowl now.req-id) now.req-id now.bowl))
+    ?:(=(now.req-id *@da) now.bowl now.req-id)
   =/  creator=ship
     ?:  &(=(our.bowl src.bowl) ?!(=(src.req-id our.bowl)))
       src.req-id
     src.bowl
   :: create with unique id
   ::
-  =?  created-time  (lth (sub now.bowl created-time) ~s30)
+  =?  created-time  |((gth created-time now.bowl) (lth (sub now.bowl created-time) ~s30))
     |-
     =/  =id:common  [creator created-time]
     ?~  get=(get-db type.input-row path.input-row id state)

--- a/realm/lib/passport.hoon
+++ b/realm/lib/passport.hoon
@@ -704,8 +704,10 @@
   ^-  (quip card state-0)
   ?>  =(src.bowl our.bowl)
   =/  id  (our-passport-id:scries bowl)
+  =/  cid  (our-contact-id:scries bowl)
   :_  state
   :~  [%pass /dbpoke %agent [our.bowl %bedrock] %poke db-action+!>([%remove [our.bowl *@da] passport-type:common /private id])]
+      [%pass /dbpoke %agent [our.bowl %bedrock] %poke db-action+!>([%remove [our.bowl *@da] contact-type:common /private cid])]
       [%pass /dbpoke %agent [our.bowl dap.bowl] %poke passport-action+!>([%init-our-passport ~])]
   ==
 ::

--- a/realm/lib/passport.hoon
+++ b/realm/lib/passport.hoon
@@ -742,8 +742,10 @@
     =/  p=passport:common
       [our-contact ~ %online %.y ~ ~ '' ~ ~ *passport-crypto:common]
     =/  cards=(list card)
-    :~  (create our.bowl passport-type:common [%passport p])
-        (create our.bowl contact-type:common [%contact contact.p])
+    :: ~s0..1000 create these records 1/16 of a second in the
+    :: future to prevent delete-log confusion
+    :~  (create-req our.bowl passport-type:common [%passport p] [our.bowl (add ~s0..1000 now.bowl)])
+        (create-req our.bowl contact-type:common [%contact contact.p] [our.bowl (add ~s0..1000 now.bowl)])
     ==
     [cards state]
     
@@ -763,8 +765,10 @@
   =/  p=passport:common
     [our-contact ~ %online %.y ~ ~ '' ~ ~ *passport-crypto:common]
   =/  cards=(list card)
-    :-  (create our.bowl passport-type:common [%passport p])
-    :-  (create our.bowl contact-type:common [%contact contact.p])
+    :: ~s0..1000 create these records 1/16 of a second in the
+    :: future to prevent delete-log confusion
+    :-  (create-req our.bowl passport-type:common [%passport p] [our.bowl (add ~s0..1000 now.bowl)])
+    :-  (create-req our.bowl contact-type:common [%contact contact.p] [our.bowl (add ~s0..1000 now.bowl)])
     ^-  (list card)
     %+  weld
       ^-  (list card)


### PR DESCRIPTION
the problem is that the delete of the old contact + passport happens at the "exact same" time as the creation of the new one, since it all happens in the same urbit event
thus, the client will have a delete log for a timestamp equal to the created at of the new record
if you changed the client logic to be "less than" only (for applying delete log) it should fix the issue
but this pr changes the agent so that the new record is created slightly after the old one was deleted