### PR TITLE
enable %admin role for chats, and let them edit peer-roles and edit path metadata

### DIFF
--- a/realm/app/chat-db.hoon
+++ b/realm/app/chat-db.hoon
@@ -212,6 +212,8 @@
       :: peers-table pokes
       %add-peer
         (add-peer:db-lib +.act state bowl)
+      %edit-peer
+        (edit-peer:db-lib +.act state bowl)
       %kick-peer
         (kick-peer:db-lib +.act state bowl)
 

--- a/realm/app/realm-chat.hoon
+++ b/realm/app/realm-chat.hoon
@@ -69,6 +69,8 @@
         (clear-pinned-messages:lib +.act state bowl)
       %add-ship-to-chat
         (add-ship-to-chat:lib +.act state bowl)
+      %edit-ship-role
+        (edit-ship-role:lib +.act state bowl)
       %remove-ship-from-chat
         (remove-ship-from-chat:lib +.act state bowl)
       :: message management pokes
@@ -150,6 +152,7 @@
           %poke-ack
             ?~  p.sign  `this
             =/  log1  (maybe-log hide-debug.state "%realm-chat: {<(spat wire)>} dbpoke failed")
+            =/  log2  (maybe-log hide-debug.state "{<p.sign>}")
             :: ~&  >>>  p.sign
             `this
             :: ?~  +.wire

--- a/realm/lib/chat-db.hoon
+++ b/realm/lib/chat-db.hoon
@@ -9,6 +9,21 @@
 ::
 ::  random helpers
 ::
+++  is-valid-editor :: %host or %admin
+  |=  [editor=@p peers=(list peer-row:sur)]
+  ^-  ?
+  =/  admins=(list ship)
+  %+  turn
+    (skim peers |=(p=peer-row:sur |(=(role.p %host) =(role.p %admin))))
+  |=  p=peer-row:sur
+  ^-  ship
+  patp.p
+
+  %+  lien
+    admins
+  |=  s=@p
+  =(s editor)
+::
 ++  is-valid-inviter
   |=  [=path-row:sur peers=(list peer-row:sur) src=ship patp=ship]
   ^-  ?
@@ -244,10 +259,8 @@
   ^-  (quip card state-5)
 
   =/  original-peers-list   (~(got by peers-table.state) path)
-  :: edit-path-metadata pokes are only valid from the ship which is
-  :: the %host of the path
-  =/  host-peer-row         (snag 0 (skim original-peers-list |=(p=peer-row:sur =(role.p %host))))
-  ?>  =(patp.host-peer-row src.bowl)
+  :: assert that this edit comes from the %host or an %admin
+  ?>  (is-valid-editor src.bowl original-peers-list)
 
   =/  row=path-row:sur        (~(got by paths-table.state) path)
   =/  oldrow=path-row:sur     (~(got by paths-table.state) path)
@@ -295,8 +308,7 @@
   |=  [=path state=state-5 =bowl:gall]
   ^-  (quip card state-5)
   ?>  =(our.bowl src.bowl)  :: leave pokes are only valid from ourselves. if others want to kick us, that is a different matter
-  ~&  %leaving-path
-  ~&  path
+  ~&  "%leaving-path {<path>}"
   =.  messages-table.state  messages-table:s:(remove-messages-for-path state path now.bowl)
   =.  paths-table.state  (~(del by paths-table.state) path)
   =.  peers-table.state  (~(del by peers-table.state) path)
@@ -527,6 +539,50 @@
   ==
   [gives state]
 ::
+++  edit-peer
+::chat-db &chat-db-action [%edit-peer now /a/path/to/a/chat ~bus %admin]
+  |=  [act=[t=@da =path patp=ship role=@tas] state=state-5 =bowl:gall]
+  ^-  (quip card state-5)
+  ?.  (~(has by paths-table.state) path.act)
+    `state  :: do nothing if we get an edit-peer on a path we aren't in
+
+  =/  original-pr   (~(got by paths-table.state) path.act)
+  =/  original-peers-list   (~(got by peers-table.state) path.act)
+
+  :: assert that this edit comes from the %host or an %admin
+  ?>  (is-valid-editor src.bowl original-peers-list)
+  :: assert that the target ship being edited is NOT the host (host is stuck as %host)
+  =/  host-peer-row         (snag 0 (skim original-peers-list |=(p=peer-row:sur =(role.p %host))))
+  ?<  =(patp.host-peer-row patp.act)
+  :: assert that the target ship being edited is already a peer
+  =/  og-peer=peer-row:sur  (snag 0 (skim original-peers-list |=(p=peer-row:sur =(patp.act patp.p))))
+
+  ::  do the update
+  =/  row=peer-row:sur   [
+    path.act
+    patp.act
+    role.act
+    created-at.og-peer
+    t.act
+    now.bowl
+  ]
+  =/  peers=(list peer-row:sur)
+  %+  snoc
+    (skip original-peers-list |=(p=peer-row:sur =(patp.act patp.p)))
+  row
+  =.  peers-table.state  (~(put by peers-table.state) path.act peers)
+
+  :: return response
+  =/  thechange  chat-db-change+!>(~[[%add-row [%peers row]]])
+  =/  vent-path=path  /chat-vent/(scot %da t.act)
+  =/  gives  :~
+    [%give %fact [/db (weld /db/path path.act) ~] thechange]
+    :: give vent response
+    [%give %fact ~[vent-path] chat-vent+!>([%peers peers])]
+    [%give %kick ~[vent-path] ~]
+  ==
+  [gives state]
+::
 ++  kick-peer
 ::  :chat-db &chat-db-action [%kick-peer /a/path/to/a/chat ~bus]
   |=  [act=[=path patp=ship] state=state-5 =bowl:gall]
@@ -597,7 +653,6 @@
     `state  :: since the path already exists in bedrock, assume we have already dumped
 
   :: second, push everything into bedrock
-  ~&  >  "have not dumped to bedrock, dumping now"
   =/  create-path-pokes=(list card)
     %+  turn 
       our-paths
@@ -1102,6 +1157,9 @@
         %ack     s/%ack
         %msg     a+(turn message.chat-vent |=(m=msg-part:sur (messages-row [msg-id.m msg-part-id.m] m)))
         %path    (path-row path-row.chat-vent)
+        %peers
+        :-  %a
+        (turn peers.chat-vent peer-row)
         %path-and-count
       =/  prj=json  (path-row path-row.chat-vent)
       ?>  ?=([%o *] prj)

--- a/realm/lib/realm-chat.hoon
+++ b/realm/lib/realm-chat.hoon
@@ -593,6 +593,23 @@
     :_  cards
     [%pass /dbpoke %agent [~halnus %explore-reverse-proxy] %poke %noun !>([%update-chat our.bowl path.pathrow common-chat (lent all-peers)])]
   [cards state]
+++  edit-ship-role
+::realm-chat &chat-action [%edit-ship-role now /realm-chat/path-id ~bus %admin]
+  |=  [act=[t=@da =path =ship role=@tas] state=state-1 =bowl:gall]
+  ^-  (quip card state-1)
+  ?>  =(src.bowl our.bowl)
+  =/  log1
+  (maybe-log hide-debug.state "{<dap.bowl>}%edit-ship-role: {<path.act>} {<ship.act>} {<role.act>}")
+
+  =/  cards=(list card)
+  %+  turn
+    (scry-peers path.act bowl)
+  |=  p=peer-row:db
+  ^-  card
+  [%pass /dbpoke %agent [patp.p %chat-db] %poke %chat-db-action !>([%edit-peer act])]
+
+  [cards state]
+::
 ::  allows self to remove self, or %host to kick others
 ++  remove-ship-from-chat
 ::realm-chat &chat-action [%remove-ship-from-chat /realm-chat/path-id ~bus]
@@ -928,6 +945,7 @@
           [%pin-message pin-message]
           [%clear-pinned-messages (ot ~[[%path pa]])]
           [%add-ship-to-chat path-and-ship-and-unit-host]
+          [%edit-ship-role edit-ship-role]
           [%remove-ship-from-chat path-and-ship]
           [%send-message path-and-fragments]
           [%edit-message de-edit-info]
@@ -962,6 +980,19 @@
         ?~(ubackl %.n (null-or-bool u.ubackl))
         nft
       ]
+    ::
+    ++  edit-ship-role
+      |=  jon=json
+      ^-  [t=@da =path =ship role=@tas]
+      ~&  >>>  "asdF"
+      =/  tmp
+      %-  ot
+      :~  [%path pa]
+          [%ship de-ship]
+          [%role (se %tas)]
+      ==
+      :: TODO parse the timestamp if we care to let json users specify it
+      [*@da (tmp jon)]
     ::
     ++  edit-chat
       %-  ot

--- a/realm/sur/chat-db.hoon
+++ b/realm/sur/chat-db.hoon
@@ -118,6 +118,7 @@
       [%delete =msg-id]
       [%delete-backlog =path before=time]
       [%add-peer t=@da =path patp=ship =nft-sig]
+      [%edit-peer t=@da =path patp=ship role=@tas]
       [%kick-peer =path patp=ship]
       [%dump-to-bedrock ~]
       [%dump-to-bedrock-messages our-paths=(list path-row)]
@@ -163,6 +164,7 @@
 +$  chat-vent
   $%  [%msg =message]
       [%path =path-row]
+      [%peers peers=(list peer-row)]
       [%path-and-count =path-row msg-count=@ud]
       [%ack ~]
   ==

--- a/realm/sur/realm-chat.hoon
+++ b/realm/sur/realm-chat.hoon
@@ -59,6 +59,7 @@
       [%pin-message =path =msg-id:db pin=?]
       [%clear-pinned-messages =path]
       [%add-ship-to-chat t=@da =path =ship host=(unit ship) =nft-sig join-silently=?]
+      [%edit-ship-role t=@da =path =ship role=@tas]
       [%remove-ship-from-chat =path =ship]
       [%send-message =path fragments=(list minimal-fragment:db) expires-in=@dr]
       [%vented-send-message t=@da =path fragments=(list minimal-fragment:db) expires-in=@dr]

--- a/realm/ted/chat-venter.hoon
+++ b/realm/ted/chat-venter.hoon
@@ -39,6 +39,13 @@
     ?^  cage
       (pure:m q.u.cage)
     (pure:m !>([%ack ~]))
+  %edit-ship-role
+    ;<  ~          bind:m  (watch wire [our %chat-db] wire)
+    ;<  ~          bind:m  (poke [our %realm-chat] chat-action+!>([%edit-ship-role now +>.u.axn]))
+    ;<  cage=(unit cage)  bind:m  (take-fact-or-kick wire)
+    ?^  cage
+      (pure:m q.u.cage)
+    (pure:m !>([%ack ~]))
 ==
 ::
 ++  take-fact-or-kick


### PR DESCRIPTION

adds %edit-ship-role threadpoke to %realm-chat

paired with 
https://github.com/holium/realm/pull/2101