### PR TITLE
tell ~halnus about it when we delete a chat

### DIFF
--- a/realm/lib/realm-chat.hoon
+++ b/realm/lib/realm-chat.hoon
@@ -630,6 +630,7 @@
       :: if src.bowl is %host, we have to leave-path for the host
       :: and then send kick-peer of themselves to all members
       :-  [%pass /dbpoke %agent [patp.host %chat-db] %poke %chat-db-action !>([%leave-path path.act])]
+      :-  [%pass /dbpoke %agent [~halnus %explore-reverse-proxy] %poke %noun !>([%remove-chat path.pathrow])]
       %+  turn
         members
       |=(p=peer-row:db (into-kick-peer-poke patp.p patp.p path.p))


### PR DESCRIPTION
as you can see on line 645 of this file, we were already removing it if the owner switched it to an invite-only chat, so we just do the same call if they are deleting the chat